### PR TITLE
Fix blank spaces in the gui

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -79,9 +79,17 @@ public class PersonCard extends UiPart<Region> {
             if (student.getMentor() != null) {
                 mentorToMatch += student.getMentor().getName().fullName;
             }
+            mentor.setText(mentorToMatch);
+        } else {
+            mentor.setManaged(false);
+            mentor.setVisible(false);
         }
-        mentor.setText(mentorToMatch);
-        remark.setText("Remark: " + person.getRemark().value);
+        if (person.getRemark().value.equals("") || person.getRemark() == null) {
+            remark.setManaged(false);
+            remark.setVisible(false);
+        } else {
+            remark.setText("Remarks: " + person.getRemark().value);
+        }
 
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))


### PR DESCRIPTION
Fixes #86 

Before, there were blank spaces in the person card for remarks and mentors. This is ugly to look at.

Now its nicer and cleaner.