### PR TITLE
Fix invalid message for edit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -118,8 +118,6 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Remark updatedRemark = personToEdit.getRemark();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-
-        String updateRole = editPersonDescriptor.getRole().orElse(personToEdit.getRole());
         Centre updatedCentre = editPersonDescriptor.getCentre()
                 .orElseGet(() -> {
                     if (personToEdit instanceof Student) {
@@ -132,22 +130,20 @@ public class EditCommand extends Command {
                 });
         Person person;
 
-        switch (updateRole.toString()) {
-        case "Mentor":
-            person = new Mentor(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRemark,
-                    updatedTags, updatedCentre);
-            break;
-        case "Student":
-            Student newStudent = new Student(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRemark,
-                    updatedTags, updatedCentre);
-            Mentor mentor = ((Student) personToEdit).getMentor();
+        if (personToEdit instanceof Mentor mentor) {
+            person = new Mentor(updatedName, updatedPhone, updatedEmail, updatedAddress,
+                    updatedRemark, updatedTags, updatedCentre);
+        } else if (personToEdit instanceof Student student) {
+            Student newStudent = new Student(updatedName, updatedPhone, updatedEmail, updatedAddress,
+                    updatedRemark, updatedTags, updatedCentre);
+            Mentor mentor = student.getMentor();
             if (mentor != null && mentor.getCentre().equals(updatedCentre)) {
                 newStudent.setMentor(mentor);
             }
             person = newStudent;
-            break;
-        default:
-            person = new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRemark, updatedTags);
+        } else {
+            person = new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
+                    updatedRemark, updatedTags);
         }
 
         return person;
@@ -186,7 +182,6 @@ public class EditCommand extends Command {
         private Phone phone;
         private Email email;
         private Address address;
-        private String role;
         private Centre centre;
         private Set<Tag> tags;
 
@@ -201,7 +196,6 @@ public class EditCommand extends Command {
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setAddress(toCopy.address);
-            setRole(toCopy.role);
             setCentre(toCopy.centre);
             setTags(toCopy.tags);
         }
@@ -243,14 +237,6 @@ public class EditCommand extends Command {
 
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
-        }
-
-        public void setRole(String role) {
-            this.role = role;
-        }
-
-        private Optional<String> getRole() {
-            return Optional.ofNullable(role);
         }
 
         public void setCentre(Centre centre) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CENTRE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -35,7 +34,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_ROLE, PREFIX_TAG, PREFIX_CENTRE);
+                        PREFIX_TAG, PREFIX_CENTRE);
 
         Index index;
 


### PR DESCRIPTION
Fixes #96 

Last time, we could edit role. However, we changed the behaviour so that we cannot edit role. Therefore, we must remove any residue from that time. edit 1 r/ was showing that the field cannot be empty instead of an invalid command format despite it being an invalid command format.

Now when users try to edit role using r/, the system will show that its an invalid command format.