### PR TITLE
Fix blank space at the bottom

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,8 +29,8 @@
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
 
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
-      <padding>
+    <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0" spacing="2">
+    <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
 


### PR DESCRIPTION
Before when a person had a field missing
it would show up as blank space at the bottom
of the person card.

Removing the minHeight now will make it so that
there would be no blank space at the bottom.